### PR TITLE
The build should fail when :BuildFail is used

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -26,6 +26,9 @@ goto End
 
 :End
 echo.
+
+set ReturnCode=%ERRORLEVEL%
+
 call npm run test-view-stop
 
 :: node.exe continues to run on a TeamCity build agent,
@@ -34,4 +37,5 @@ call npm run test-view-stop
 :: on the machine, but it should fix this issue (for now, at least).
 call taskkill /F /IM node.exe
 popd
-exit /B %ERRORLEVEL%
+
+exit /B %ReturnCode%


### PR DESCRIPTION
If a test failure happens, the build script should return the expected return code.