### PR TITLE
Update linting

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,6 +2,8 @@
   "extends": "stylelint-config-standard",
   "rules": {
     "at-rule-empty-line-before": null,
+    "declaration-empty-line-before": null,
+    "rule-nested-empty-line-before": null,
     "selector-pseudo-element-colon-notation": null
   }
 }

--- a/css/scss/mixins/_breakpoints.scss
+++ b/css/scss/mixins/_breakpoints.scss
@@ -7,7 +7,7 @@ $breakpoints: (
   phablet:     765px,
   tablet:      991px,
   desktop:     1200px
-  );
+);
 
 // When we only need to return below a breakpoint
 // Usage: @media (max-width: break-target(phone))

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "gulp-webserver": "^0.9.1",
     "opn": "^4.0.1",
     "spawn-cmd": "0.0.2",
-    "stylelint": "^6.5.1",
-    "stylelint-config-standard": "^8.0.0"
+    "stylelint": "^7.1.0",
+    "stylelint-config-standard": "^12.0.0"
   },
   "files": [
     "css",


### PR DESCRIPTION
Update linting, fixes the following deprecation warning:

```
Deprecation Warning: 'number-zero-length-no-unit' has been deprecated, and will be removed in '7.0'. Use 'length-zero-no-unit' instead. See: http://stylelint.io/user-guide/rules/length-zero-no-unit/
```
